### PR TITLE
Extend user schema to fetch lots for user from Mongo.

### DIFF
--- a/db/mongo-test-data.js
+++ b/db/mongo-test-data.js
@@ -9,6 +9,7 @@ MongoClient.connect(mongoConfig.url, (err, db) => {
     .collection('lots')
     .insertMany([
       {
+        userId: 1,
         symbol: 'MMM',
         costBasis: 200.00,
         shares: 10,
@@ -16,6 +17,7 @@ MongoClient.connect(mongoConfig.url, (err, db) => {
         memo: 'predicting strong earnings',
       },
       {
+        userId: 1,
         symbol: 'MMM',
         costBasis: 210.00,
         shares: 5,

--- a/db/mongodb.js
+++ b/db/mongodb.js
@@ -1,10 +1,11 @@
 module.exports = mongoPool => {
   return {
-    get(user) {
+    getLots(user) {
       return mongoPool
         .collection('lots')
         .find({ userId: user.id })
-        .then(lot => lot);
+        .toArray()
+        .then(lots => lots);
     },
   };
 };

--- a/db/mongodb.js
+++ b/db/mongodb.js
@@ -1,0 +1,10 @@
+module.exports = mongoPool => {
+  return {
+    get(user) {
+      return mongoPool
+        .collection('lots')
+        .find({ userId: user.id })
+        .then(lot => lot);
+    },
+  };
+};

--- a/db/pgdb.js
+++ b/db/pgdb.js
@@ -5,28 +5,22 @@ module.exports = pgPool => {
     getUser(apiKey) {
       return pgPool
         .query(
-          `
-
+        `
         SELECT * FROM users
-
         WHERE api_key = $1
-
       `,
-          [apiKey]
+        [apiKey]
         )
         .then(res => humps.camelizeKeys(res.rows[0]));
     },
     getWatchlists(user) {
       return pgPool
         .query(
-          `
-
+        `
         SELECT * FROM lists
-
         WHERE created_by = $1
-
       `,
-          [user.id]
+        [user.id]
         )
         .then(res => humps.camelizeKeys(res.rows));
     },

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,30 +1,37 @@
 // Init reading from .env file.
 require('dotenv').config();
 
+// Init the HTTP server.
+const app = require('express')();
+
 const graphqlHttp = require('express-graphql');
 const { nodeEnv } = require('./util');
+
+const ljSchema = require('../schema');
 
 const pg = require('pg');
 const pgConfig = require('../config/pg')[nodeEnv];
 const pgPool = new pg.Pool(pgConfig);
 
-const ljSchema = require('../schema');
+const { MongoClient } = require('mongodb');
+const assert = require('assert');
+const mongoConfig = require('../config/mongo')[nodeEnv];
+console.log(mongoConfig.url);
 
-// Init the HTTP server.
-const app = require('express')();
+MongoClient.connect(mongoConfig.url, (err, mongoPool) => {
+  assert.equal(err, null);
 
-app.use(
-  '/graphql',
-  graphqlHttp({
-    schema: ljSchema,
-    graphiql: true,
-    context: {
-      pgPool,
-    },
-  })
-);
+  const PORT = process.env.APP_PORT;
+  app.listen(PORT, () => {
+    console.log(`Server is listening on port ${PORT}`);
+  });
 
-const PORT = process.env.APPPORT;
-app.listen(PORT, () => {
-  console.log(`Server is listening on port ${PORT}`);
+  app.use(
+    '/graphql',
+    graphqlHttp({
+      schema: ljSchema,
+      graphiql: true,
+      context: { pgPool, mongoPool },
+    })
+  );
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,22 +16,18 @@ const pgPool = new pg.Pool(pgConfig);
 const { MongoClient } = require('mongodb');
 const assert = require('assert');
 const mongoConfig = require('../config/mongo')[nodeEnv];
-console.log(mongoConfig.url);
 
 MongoClient.connect(mongoConfig.url, (err, mongoPool) => {
   assert.equal(err, null);
 
-  const PORT = process.env.APP_PORT;
+  app.use('/graphql', graphqlHttp({
+    schema: ljSchema,
+    graphiql: true,
+    context: { pgPool, mongoPool }
+  }));
+
+  const PORT = process.env.PORT || 3000;
   app.listen(PORT, () => {
     console.log(`Server is listening on port ${PORT}`);
   });
-
-  app.use(
-    '/graphql',
-    graphqlHttp({
-      schema: ljSchema,
-      graphiql: true,
-      context: { pgPool, mongoPool },
-    })
-  );
 });

--- a/schema/index.js
+++ b/schema/index.js
@@ -6,6 +6,7 @@ const {
 } = require('graphql');
 
 const pgdb = require('../db/pgdb');
+
 const UserType = require('./types/user');
 
 const RootQueryType = new GraphQLObjectType({
@@ -13,7 +14,7 @@ const RootQueryType = new GraphQLObjectType({
   fields: {
     user: {
       type: UserType,
-      description: '',
+      description: '', // TODO
       args: {
         apiKey: { type: new GraphQLNonNull(GraphQLString) },
       },

--- a/schema/types/lot.js
+++ b/schema/types/lot.js
@@ -1,0 +1,20 @@
+const {
+  GraphQLFloat,
+  GraphQLID,
+  GraphQLNonNull,
+  GraphQLObjectType,
+  GraphQLString,
+} = require('graphql');
+
+module.exports = new GraphQLObjectType({
+  name: 'LotType',
+  fields: {
+    id: { type: GraphQLID },
+    userId: { type: new GraphQLNonNull(GraphQLString) },
+    symbol: { type: new GraphQLNonNull(GraphQLString) },
+    costBasis: { type: GraphQLFloat },
+    shares: { type: GraphQLFloat },
+    tradeDate: { type: GraphQLString },
+    memo: { type: GraphQLString },
+  },
+});

--- a/schema/types/user.js
+++ b/schema/types/user.js
@@ -7,6 +7,8 @@ const {
 } = require('graphql');
 
 const pgdb = require('../../db/pgdb');
+const mongodb = require('../../db/mongodb');
+
 const WatchlistType = require('./watchlist');
 
 module.exports = new GraphQLObjectType({
@@ -23,5 +25,6 @@ module.exports = new GraphQLObjectType({
         return pgdb(pgPool).getWatchlists(obj);
       },
     },
+    lots: {},
   },
 });

--- a/schema/types/user.js
+++ b/schema/types/user.js
@@ -10,6 +10,7 @@ const pgdb = require('../../db/pgdb');
 const mongodb = require('../../db/mongodb');
 
 const WatchlistType = require('./watchlist');
+const LotType = require('./lot');
 
 module.exports = new GraphQLObjectType({
   name: 'UserType',
@@ -25,6 +26,11 @@ module.exports = new GraphQLObjectType({
         return pgdb(pgPool).getWatchlists(obj);
       },
     },
-    lots: {},
+    lots: {
+      type: new GraphQLList(LotType),
+      resolve(obj, args, { mongoPool }) {
+        return mongodb(mongoPool).getLots(obj);
+      },
+    },
   },
 });

--- a/schema/types/watchlist.js
+++ b/schema/types/watchlist.js
@@ -15,5 +15,6 @@ module.exports = new GraphQLObjectType({
     description: { type: GraphQLString },
     portfolioType: { type: new GraphQLNonNull(WatchlistPortfolioType) },
     createdAt: { type: GraphQLString },
+    createdBy: { type: new GraphQLNonNull(GraphQLString) },
   },
 });


### PR DESCRIPTION
## Summary
Following along from [Pluralsight course](https://app.pluralsight.com/library/courses/graphql-scalable-apis) through module 3. Fetch a users' Lots from Mongo via Users schema. Eventually, lots and watchlists will be separated from the `user` query.